### PR TITLE
use service token for authentication

### DIFF
--- a/cc-snapshot
+++ b/cc-snapshot
@@ -204,6 +204,7 @@ if hash jq 2>/dev/null; then
   SITE=$(echo $JSON_VENDOR_DATA | jq -r .site)
   REGION=$(echo $JSON_VENDOR_DATA | jq -r .region)
   PROJECT_ID=$(echo $JSON_VENDOR_DATA | jq -r .project_id)
+  TOKEN=$(echo $JSON_VENDOR_DATA | jq -r .service_token)
 else
   # jq not available
   function extract_json_key {
@@ -213,6 +214,7 @@ else
   SITE=$(extract_json_key "site" "$JSON_VENDOR_DATA")
   REGION=$(extract_json_key "region" "$JSON_VENDOR_DATA")
   PROJECT_ID=$(extract_json_key "project_id" "$JSON_VENDOR_DATA")
+  TOKEN=$(extract_json_key "service_token" "$JSON_VENDOR_DATA")
 fi
 
 if [ "$SITE" != "tacc" ] && [ "$SITE" != "uc" ]; then
@@ -228,22 +230,8 @@ if [ -z "$OS_REGION_NAME" ]; then unset OS_REGION_NAME; fi
 export OS_AUTH_URL=$(echo $CHAMELEON_OS_AUTH_URL_TMPL | sed "s/SITE/$SITE/g")
 export OS_IDENTITY_API_VERSION=3
 export OS_PROJECT_ID=$PROJECT_ID
-
-if [ -z "${OS_TOKEN+x}" ]; then
-  if [ -z "${OS_USERNAME+x}" ]; then
-    echo "Please enter your Chameleon username: "
-    read -r OS_USERNAME_INPUT
-    export OS_USERNAME=$OS_USERNAME_INPUT
-  fi
-
-  if [ -z "${OS_PASSWORD+x}" ]; then
-    echo "Please enter your Chameleon password: "
-    read -sr OS_PASSWORD_INPUT
-    export OS_PASSWORD=$OS_PASSWORD_INPUT
-  fi
-
-  export OS_USER_DOMAIN_NAME="Default"
-fi
+export OS_TOKEN=$TOKEN
+export OS_AUTH_TYPE="token"
 
 set +e
 openstack image list >/dev/null #2>&1


### PR DESCRIPTION
Using username and password for keystone authentication doesn't work for
federated users. We'll get the service token from the vendordata and use
the token for authentication.