### PR TITLE
use findmnt instead of findfs to list all mounted devices of ext4

### DIFF
--- a/cc-snapshot
+++ b/cc-snapshot
@@ -300,7 +300,7 @@ fi
 FS="ext4"
 
 [[ -n ${LABEL:-} ]] || {
-  LABEL="$(e2label $(findfs TYPE=$FS))"
+  LABEL="$(sudo e2label $(findmnt -t ext4 -J | jq -r ".filesystems[].source" ))"
   if [ ! -L "/dev/disk/by-label/$LABEL" ]; then
     LABEL="$(ls -1 /dev/disk/by-label)"
     if [[ "$(wc -l <<<"$LABEL")" != "1" ]]; then


### PR DESCRIPTION
The error when trying to snapshot the instance:

```
Unable to auto-detect disk label: found >1 labeled disks:
cloudimg-rootfs
MKFS_ESP
Please try again while explicitly setting the LABEL
env variable to the desired disk label.
```

The devices:
```
sudo lsblk -o NAME,SIZE,LABEL
NAME      SIZE LABEL
loop0    63.2M
loop1    63.3M
loop2    67.8M
loop3    91.9M
loop4    49.8M
loop5    40.9M
sda     186.3G
├─sda1    550M MKFS_ESP
├─sda2      8M
└─sda3  185.8G cloudimg-rootfs
nvme0n1   1.5T
```

Probably `findfs` is returning disks even if they are not mounted so this change is needed.