### PR TITLE
This fixes when there is no /boot/efi dir (boot_mode==bios)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,18 @@ cc-snapshot will ask for your Chameleon password, and after a few minutes, a sna
     sudo yum makecache
     sudo yum update lvm2
     ```
+
+## Supported Operating Systems
+
+cc-snapshot supports the following operating systems:
+
+### CentOS Distributions
+
+- CentOS Linux
+- CentOS Stream
+
+### Ubuntu Distributions
+
+- All Ubuntu distributions
+
+**Note:** The script is also designed to work with non-UEFI boot installations of Ubuntu.

--- a/cc-snapshot
+++ b/cc-snapshot
@@ -252,6 +252,18 @@ if [ $DISTRO = $CENTOS ] && [ $CENTOS_VERSION -eq 7 ]; then
   yum update -y lvm2 # must be at least 2.02-171 to avoid bug https://bugzilla.redhat.com/show_bug.cgi?id=1475018
 fi
 
+
+if [ $DISTRO = $UBUNTU ]; then
+  # Ensure /boot/efi directory exists and install grub-efi if it doesn't
+  if [ ! -d /boot/efi ]; then
+    echo "Creating /boot/efi directory..."
+    sudo mkdir -p /boot/efi
+    echo "Installing grub-efi..."
+    apt-get install -yq grub-efi
+  fi
+fi
+
+
 # Create a tar file of the contents of your instance:
 declare -a TAR_ARGS=(--selinux --acls --numeric-owner --one-file-system --exclude-from $EXCLUDE_FROM)
 if [ $DISTRO = $CENTOS ]; then


### PR DESCRIPTION
THe fix is to create a /boot/efi dir when it does not exist. Error raised with no dir: libguestfs: error: mount: mount: /boot/efi: No such file or directory

When the path is created, another error is raised - libguestfs: error: sh: /usr/sbin/grub-install: error: /usr/lib/grub/x86_64-efi/modinfo.sh doesn't exist. Please specify --target or --directory.

To fix this, we need to install `grub-efi` for ubuntu distro

This all needs to be done before the tar file of the instance is created, so the guestfish can see all the changes