### PR TITLE
Update cc-snapshot to add a flag for faster zstd instead of zlib compression

### DIFF
--- a/cc-snapshot
+++ b/cc-snapshot
@@ -48,7 +48,7 @@ print_usage() {
   echo "  -u        Skip the automatic self-update check"
   echo "  -s        Specify any path other than root for snapshoting"
   echo "  -o        Use existing OpenStack environment credentials instead of vendor data"
-  echo "  -z        Use faster zstd compression (default is zlib). Note: launching images compressed with zstd may not be supported on all sites."
+  echo "  -z        Use faster zstd compression (default is zlib). Note: launching images compressed with zstd may not be supported on sites running OpenStack Xena or earlier."
   echo ""
   echo " cc-snapshot version 0.2.0"
 }
@@ -492,7 +492,7 @@ create_disk_image(){
   # To complete the preparation of your snapshot image, create a compressed version of it:
   if [[ "$USE_ZSTD" == true ]]; then
     echo "INFO: Using zstd compression for qcow2 image."
-    echo "INFO: After upload, please verify you can successfully launch an instance from this image. Some sites may not support images compressed with zstd."
+    echo "INFO: After upload, please verify you can successfully launch an instance from this image. Sites running OpenStack Xena or earlier may not support images compressed with zstd."
     COMPRESSION_TYPE="zstd"
     run_cmd qemu-img convert $CC_SNAPSHOT_CONVERTED_PATH -O $CC_SNAPSHOT_DISK_FORMAT -c -o compression_type=zstd $CC_SNAPSHOT_CONVERTED_COMPRESSED_PATH
   else

--- a/cc-snapshot
+++ b/cc-snapshot
@@ -33,7 +33,7 @@ FORCE_YES=false
 SKIP_UPDATE=false
 DRY_RUN=false
 USE_OS_ENV=false
-USE_LEGACY_ZLIB=false
+USE_ZSTD=false
 SOURCE_DIR="/"
 
 print_usage() {
@@ -48,7 +48,7 @@ print_usage() {
   echo "  -u        Skip the automatic self-update check"
   echo "  -s        Specify any path other than root for snapshoting"
   echo "  -o        Use existing OpenStack environment credentials instead of vendor data"
-  echo "  -z        Use legacy zlib compression (default is zstd)"
+  echo "  -z        Use faster zstd compression (default is zlib). Note: launching images compressed with zstd may not be supported on all sites."
   echo ""
   echo " cc-snapshot version 0.2.0"
 }
@@ -110,7 +110,7 @@ while getopts "hpe:fyduos:z" opt; do
       USE_OS_ENV=true
       ;;
     z)
-      USE_LEGACY_ZLIB=true
+      USE_ZSTD=true
       ;;
     \?)
       echo "Invalid option: -$OPTARG" >&2
@@ -490,10 +490,14 @@ create_disk_image(){
   run_cmd virt-sysprep -a $CC_SNAPSHOT_CONVERTED_PATH
 
   # To complete the preparation of your snapshot image, create a compressed version of it:
-  if [[ "$USE_LEGACY_ZLIB" == true ]]; then
-    run_cmd qemu-img convert $CC_SNAPSHOT_CONVERTED_PATH -O $CC_SNAPSHOT_DISK_FORMAT $CC_SNAPSHOT_CONVERTED_COMPRESSED_PATH -c
-  else
+  if [[ "$USE_ZSTD" == true ]]; then
+    echo "INFO: Using zstd compression for qcow2 image."
+    echo "INFO: After upload, please verify you can successfully launch an instance from this image. Some sites may not support images compressed with zstd."
+    COMPRESSION_TYPE="zstd"
     run_cmd qemu-img convert $CC_SNAPSHOT_CONVERTED_PATH -O $CC_SNAPSHOT_DISK_FORMAT -c -o compression_type=zstd $CC_SNAPSHOT_CONVERTED_COMPRESSED_PATH
+  else
+    COMPRESSION_TYPE="zlib"
+    run_cmd qemu-img convert $CC_SNAPSHOT_CONVERTED_PATH -O $CC_SNAPSHOT_DISK_FORMAT $CC_SNAPSHOT_CONVERTED_COMPRESSED_PATH -c
   fi
 }
 
@@ -503,7 +507,8 @@ create_disk_image(){
 upload_to_glance(){
   # build the command once
   local CMD=(openstack image create --disk-format "$CC_SNAPSHOT_DISK_FORMAT" \
-              --container-format bare $PROVENANCE_PROPERTIES "$SNAPSHOT_NAME")
+              --container-format bare \
+              --property "compression_type=$COMPRESSION_TYPE" $PROVENANCE_PROPERTIES "$SNAPSHOT_NAME")
   if [[ "$DRY_RUN" == true ]]; then
     echo "[DRY_RUN] ${CMD[*]} < $CC_SNAPSHOT_CONVERTED_COMPRESSED_PATH"
     return 0

--- a/cc-snapshot
+++ b/cc-snapshot
@@ -33,10 +33,11 @@ FORCE_YES=false
 SKIP_UPDATE=false
 DRY_RUN=false
 USE_OS_ENV=false
+USE_LEGACY_ZLIB=false
 SOURCE_DIR="/"
 
 print_usage() {
-  echo "usage: $0 [-p] [-e folder_to_exclude] [-d] [-u] [-s source_dir] [-o] snapshot_name"
+  echo "usage: $0 [-p] [-e folder_to_exclude] [-d] [-u] [-s source_dir] [-o] [-z] snapshot_name"
   echo "Optional arguments:"
   echo ""
   echo "  -h        Print this help message"
@@ -47,12 +48,13 @@ print_usage() {
   echo "  -u        Skip the automatic self-update check"
   echo "  -s        Specify any path other than root for snapshoting"
   echo "  -o        Use existing OpenStack environment credentials instead of vendor data"
+  echo "  -z        Use legacy zlib compression (default is zstd)"
   echo ""
   echo " cc-snapshot version 0.2.0"
 }
 
 # Get the size of tar and warn user if exceeds threshold property
-check_size(){ 
+check_size(){
   local size_cmd=(stat -c %s $CC_SNAPSHOT_TAR_PATH)
 
   #Dry_run shows what would run
@@ -76,7 +78,7 @@ check_size(){
   fi
 }
 
-while getopts "hpe:fyduso:" opt; do
+while getopts "hpe:fyduso:z" opt; do
   case $opt in
     h)
       print_usage
@@ -107,6 +109,9 @@ while getopts "hpe:fyduso:" opt; do
     o)
       USE_OS_ENV=true
       ;;
+    z)
+      USE_LEGACY_ZLIB=true
+      ;;
     \?)
       echo "Invalid option: -$OPTARG" >&2
       print_usage
@@ -134,7 +139,7 @@ if [[ -n "${DUMMY_STAGE:-}" ]]; then
   esac
 fi
 
-#DRY_RUN helper function 
+#DRY_RUN helper function
 run_cmd() {
   if [[ "$DRY_RUN" == true ]]; then
     echo "[DRY_RUN] $*"
@@ -317,9 +322,9 @@ if [[ "$DRY_RUN" != true && "$SOURCE_DIR" == "/" ]]; then
     echo "Using existing OpenStack environment credentials."
   fi
 
-  if  [[ -n "${TESTING_SKIP_ROOT_CHECK:-}" ]]; then 
+  if  [[ -n "${TESTING_SKIP_ROOT_CHECK:-}" ]]; then
     echo "Skipping bare-metal check (requires root privileges)"
-  else 
+  else
     if dmesg | grep -q Hypervisor; then
       echo "Error: cc-snapshot is only supported for baremetal instances." >&2
       exit 1
@@ -485,7 +490,11 @@ create_disk_image(){
   run_cmd virt-sysprep -a $CC_SNAPSHOT_CONVERTED_PATH
 
   # To complete the preparation of your snapshot image, create a compressed version of it:
-  run_cmd qemu-img convert $CC_SNAPSHOT_CONVERTED_PATH -O $CC_SNAPSHOT_DISK_FORMAT $CC_SNAPSHOT_CONVERTED_COMPRESSED_PATH -c
+  if [[ "$USE_LEGACY_ZLIB" == true ]]; then
+    run_cmd qemu-img convert $CC_SNAPSHOT_CONVERTED_PATH -O $CC_SNAPSHOT_DISK_FORMAT $CC_SNAPSHOT_CONVERTED_COMPRESSED_PATH -c
+  else
+    run_cmd qemu-img convert $CC_SNAPSHOT_CONVERTED_PATH -O $CC_SNAPSHOT_DISK_FORMAT -c -o compression_type=zstd $CC_SNAPSHOT_CONVERTED_COMPRESSED_PATH
+  fi
 }
 
 ################################

--- a/cc-snapshot
+++ b/cc-snapshot
@@ -78,7 +78,7 @@ check_size(){
   fi
 }
 
-while getopts "hpe:fyduso:z" opt; do
+while getopts "hpe:fyduos:z" opt; do
   case $opt in
     h)
       print_usage

--- a/tests/test_interface.sh
+++ b/tests/test_interface.sh
@@ -16,7 +16,7 @@ pass() {
 TEST_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CC_SNAPSHOT="${TEST_SCRIPT_DIR}/../cc-snapshot"
 
-#Test if the path exist 
+#Test if the path exist
 if [[ ! -x "${CC_SNAPSHOT}" ]]; then
     echo "Error: unable to find ${CC_SNAPSHOT} or it is not executable"
     exit 1
@@ -38,12 +38,12 @@ else
   fail "-e without folder did not fail as expected"
 fi
 
-#Test 3: running with an invalid flag (-z)
-output=$(TESTING_SKIP_ROOT_CHECK=1 "$CC_SNAPSHOT" -z 2>&1) && status=0 || status=$?
+#Test 3: running with an invalid flag (-a)
+output=$(TESTING_SKIP_ROOT_CHECK=1 "$CC_SNAPSHOT" -a 2>&1) && status=0 || status=$?
 if [[ $status -ne 0 && "$output" == *"usage:"* ]]; then
-  pass "Invalid flag (-z) is handled with error"
+  pass "Invalid flag (-a) is handled with error"
 else
-  fail "Invalid flag (-z) did not trigger error as expected"
+  fail "Invalid flag (-a) did not trigger error as expected"
 fi
 
 #Test 4: Dry-run does not error and prints each step
@@ -67,13 +67,13 @@ if output=$(TESTING_SKIP_ROOT_CHECK=1 "$CC_SNAPSHOT" -d mytest 2>&1); then
 
   missing=0
   for pat in "${expected[@]}"; do
-    if ! grep -q "\[DRY_RUN\].*${pat}" <<<"$output"; then 
+    if ! grep -q "\[DRY_RUN\].*${pat}" <<<"$output"; then
       echo "Missing Dry-run for: $pat" >&2
       missing=$((missing+1))
     fi
   done
 
-  if (( missing > 0 )); then 
+  if (( missing > 0 )); then
     fail "Dry-run is missing $missing expected steps"
   else
     pass "Dry-run printed all ${#expected[@]} steps without error"
@@ -139,9 +139,9 @@ diff \
     tar -tf "$DEFAULT_TAR" | \
       # Normalize path: drop "./" prefix and "/" suffix
       sed 's|^\./||; s|/$||' | \
-      # remove any blank line 
+      # remove any blank line
       grep -v '^$' | \
-      # sort in alphabetical order for compresion 
+      # sort in alphabetical order for compresion
       sort
   ) || fail "Contents mismatch for basic snapshot"
 


### PR DESCRIPTION
Compression sizes are about the same, but with the previous method (zlib) the time to create a snapshot of Ubuntu24 was ~7min and now with zstd it's ~2min.